### PR TITLE
Convert to uint32_t before shifting left

### DIFF
--- a/sha1.c
+++ b/sha1.c
@@ -247,10 +247,10 @@ void SHA1ProcessMessageBlock(SHA1Context *context)
      */
     for(t = 0; t < 16; t++)
     {
-        W[t] = context->Message_Block[t * 4] << 24;
-        W[t] |= context->Message_Block[t * 4 + 1] << 16;
-        W[t] |= context->Message_Block[t * 4 + 2] << 8;
-        W[t] |= context->Message_Block[t * 4 + 3];
+        W[t] = ((uint32_t)context->Message_Block[t * 4]) << 24;
+        W[t] |= ((uint32_t)context->Message_Block[t * 4 + 1]) << 16;
+        W[t] |= ((uint32_t)context->Message_Block[t * 4 + 2]) << 8;
+        W[t] |= ((uint32_t)context->Message_Block[t * 4 + 3]);
     }
     
     for(t = 16; t < 80; t++)


### PR DESCRIPTION
If this is not done, the shifting zeroes out the array value, and W[t] ends up as zero for all but the last assignment.
